### PR TITLE
Fix README markdown (getInfo)

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ info = {
 ```
 
 ## Methods
-#####getInfo
+##### getInfo
 ```javascript
 // get info object
 var slider = tns(...);


### PR DESCRIPTION
A space was missing breaking the Markdown.