### PR TITLE
resolves #78 bug in addCSSRule when using webpack

### DIFF
--- a/src/helpers/addCSSRule.js
+++ b/src/helpers/addCSSRule.js
@@ -1,15 +1,11 @@
 // cross browsers addRule method
 export var addCSSRule = (function () {
-  var styleSheet = document.styleSheets[0];
-  if('insertRule' in styleSheet) {
-
-    return function (sheet, selector, rules, index) {
-      sheet.insertRule(selector + '{' + rules + '}', index);
-    };
-  } else if('addRule' in styleSheet) {
-
-    return function (sheet, selector, rules, index) {
-      sheet.addRule(selector, rules, index);
-    };
+  return function (sheet, selector, rules, index) {
+      var styleSheet = document.styleSheets[0];
+      if('insertRule' in styleSheet) {
+          sheet.insertRule(selector + '{' + rules + '}', index);
+      } else if('addRule' in styleSheet) {
+          sheet.addRule(selector, rules, index);
+      }
   }
 })();


### PR DESCRIPTION
Resolves bug where addCSSRule throws an error upon importing the module. addCSSRule can be executed before the DOM is initialised and document.styleSheets is available. This fix changes addCSSRule to determine styleSheet capabilities at time of execution instead.