### PR TITLE
feat: add 'hasControls' function to .getInfo()

### DIFF
--- a/src/tiny-slider.module.js
+++ b/src/tiny-slider.module.js
@@ -2165,6 +2165,7 @@ export var tns = function(options) {
       navContainer: navContainer,
       navItems: navItems,
       controlsContainer: controlsContainer,
+      hasControls: hasControls,
       prevButton: prevButton,
       nextButton: nextButton,
       items: items,


### PR DESCRIPTION
Now .getInfo() method return the 'hasControls' boolean value. This will help to style controls if they are exists only.

```js
const {nextButton, prevButton, hasControls} = this.slider.getInfo();
if (hasControls) {
  nextButton.className = `tiny-next-button`;
  prevButton.className = `tiny-prev-button`;
}
```