### PR TITLE
Run conditional before grabbing clientWidth

### DIFF
--- a/src/tiny-slider.js
+++ b/src/tiny-slider.js
@@ -953,8 +953,8 @@ export var tns = function(options) {
         itemsTem = items,
         freezeTem = freeze;
 
-    vpOuter = outerWrapper.clientWidth;
-    vpInner = innerWrapper.clientWidth;
+    if (outerWrapper) vpOuter = outerWrapper.clientWidth;
+    if (innerWrapper) vpInner = innerWrapper.clientWidth;
     if (breakpoints) { setBreakpointZone(); }
 
 


### PR DESCRIPTION
Fix for the issue that I reported here: https://github.com/ganlanyuan/tiny-slider/issues/144

Tiny slider is trying to check the clientWidth of an element that has been removed, so we just need to check to make sure that element is there. Tested locally in my project and is working 👍. 