### PR TITLE
fix: one item in carousel

### DIFF
--- a/src/tiny-slider.js
+++ b/src/tiny-slider.js
@@ -511,7 +511,7 @@ export var tns = function(options) {
       var str = fixedWidth ? 'fixedWidth' : 'items',
           arr = [];
 
-      if (fixedWidth || options[str] < slideCount) { arr.push(options[str]); }
+      if (fixedWidth || options[str] <= slideCount) { arr.push(options[str]); }
 
       if (breakpoints && responsiveItems.indexOf(str) >= 0) {
         breakpoints.forEach(function(bp) {


### PR DESCRIPTION
__Issue description__:  
When I have one item in the carrousel the console report this issue:

Uncaught TypeError: Cannot read property 'cloneNode' of undefined
    at sliderInit (tiny-slider.module.js:719)
    at Object.tns (tiny-slider.module.js:1069)
    at Object.initProductCarousel (CategoryPageCarousel.ts:17)
    at HTMLDocument.<anonymous> (category.ts:14)


__Demo link/slider setting__:   
Sometimes I have only one item in my carousel (for exemple when only one image is sent by an api)
```
tns({
      container: '.carousel_id',
      items: 1,
      slideBy: 'page',
      autoplay: false,
      autoplayButtonOutput: false,
      mouseDrag: true,
      swipeAngle: false,
      gutter: 40
    });
```

_Tiny-slider version_:   
```
{
  "name": "tiny-slider",
  "version": "2.7.0",
  "description": "Vanilla javascript slider for all purposes, inspired by Owl Carousel.",
  "main": "dist/tiny-slider.js",
  "directories": {
    "test": "tests"
  },
  "scripts": {
    "start": "nodemon --watch tests/js/tests-async.js --exec npm test",
    "test": "babel tests/js/tests-async.js -o tests/js/tests-async-es5.js"
  },
  "repository": {
    "type": "git",
    "url": "git+https://github.com/ganlanyuan/tiny-slider.git"
  },
  "keywords": [],
  "author": "ganlanyuan <ganlanyuan@gmail.com>",
  "license": "MIT",
  "bugs": {
    "url": "https://github.com/ganlanyuan/tiny-slider/issues"
  },
  "homepage": "https://github.com/ganlanyuan/tiny-slider#readme",
  "dependencies": {
    "babel-cli": "^6.26.0",
    "babel-core": "^6.26.3",
    "babel-polyfill": "^6.26.0",
    "babel-preset-es2015": "^6.24.1",
    "babel-preset-es2017": "^6.24.1",
    "nodemon": "^1.17.5"
  }
}
```
_Browser name && version_:  chrome Version 65.0.3325.181 (Build officiel) (64 bits) 
_OS name && version_:   ubuntu 16.04 lts


Edit:
When I look in the code, this seems cause issue:
```
function getItemsMax () {
    if (fixedWidth && !fixedWidthViewportWidth) {
      return slideCount - 1;
    } else {
      var str = fixedWidth ? 'fixedWidth' : 'items',
          isFW = fixedWidth,
          arr = [];

      if (isFW || options[str] < slideCount) { arr.push(options[str]); }

      if (breakpoints && responsiveItems.indexOf(str) >= 0) {
        breakpoints.forEach(function(bp) {
          var tem = responsive[bp][str];
          if (tem && (isFW || tem < slideCount)) { arr.push(tem); }
        });
      }

      return isFW ? Math.ceil(fixedWidthViewportWidth / Math.min.apply(null, arr)) :
        Math.max.apply(null, arr);
    }
  }
```
Because `isFW` is false and `options[str] < slideCount`  return false so we call `Math.max.apply(null, arr);` with `arr` === [] so the return is `-Infinity`