### PR TITLE
Copy srcset from data-srcset on lazyload

### DIFF
--- a/src/tiny-slider.js
+++ b/src/tiny-slider.js
@@ -1625,7 +1625,7 @@ export var tns = function(options) {
 
       for(; i < len; i++) {
         forEachNodeList(slideItems[i].querySelectorAll('.tns-lazy-img'), function (img) {
-          // stop propagationl transitionend event to container
+          // stop propagation transitionend event to container
           var eve = {};
           eve[TRANSITIONEND] = function (e) { e.stopPropagation(); };
           addEvents(img, eve);

--- a/src/tiny-slider.js
+++ b/src/tiny-slider.js
@@ -1631,6 +1631,10 @@ export var tns = function(options) {
           addEvents(img, eve);
 
           if (!hasClass(img, 'loaded')) {
+            const srcset = getAttr(img, 'data-srcset');
+            if (srcset) {
+              img.srcset = srcset;
+            }
             img.src = getAttr(img, 'data-src');
             addClass(img, 'loaded');
           }


### PR DESCRIPTION
If you specify `srcset` on images you are not able to use lazyload feature.
To fix that lib need to copy `srcset` from `data-srcset` exactly the same as for `src`.