### PR TITLE
 Add `loaded` class only if image is really loaded

### DIFF
--- a/src/tiny-slider.js
+++ b/src/tiny-slider.js
@@ -1630,14 +1630,17 @@ export var tns = function(options) {
           eve[TRANSITIONEND] = function (e) { e.stopPropagation(); };
           addEvents(img, eve);
 
-          if (!hasClass(img, 'loaded')) {
+          if (!hasClass(img, 'loading') && !hasClass(img, 'loaded')) {
             // update srcset
             var srcset = getAttr(img, 'data-srcset');
             if (srcset) { img.srcset = srcset; }
 
             // update src
+            img.onload = function() {
+              addClass(img, 'loaded')
+            }
             img.src = getAttr(img, 'data-src');
-            addClass(img, 'loaded');
+            addClass(img, 'loading');
           }
         });
       }

--- a/src/tiny-slider.js
+++ b/src/tiny-slider.js
@@ -1637,7 +1637,8 @@ export var tns = function(options) {
 
             // update src
             img.onload = function() {
-              addClass(img, 'loaded')
+              addClass(img, 'loaded');
+              removeClass(img, 'loading');
             }
             img.src = getAttr(img, 'data-src');
             addClass(img, 'loading');


### PR DESCRIPTION
It's quite strange that `loaded` class is added when src is set not when an image is really loaded, moreover it causes some bugs and unexpected behavior.

One of them that opacity transition can happen before an image is loaded. But actually, because of some web magic opacity transition **never happens** (tested in Chrome).

If we add `loaded` class when img.onload fires everything works fine.