### PR TITLE
Fix lazyload on IE11

### DIFF
--- a/src/tiny-slider.js
+++ b/src/tiny-slider.js
@@ -1633,10 +1633,6 @@ export var tns = function(options) {
           addEvents(img, eve);
 
           if (!hasClass(img, 'loading') && !hasClass(img, 'loaded')) {
-            // update srcset
-            var srcset = getAttr(img, 'data-srcset');
-            if (srcset) { img.srcset = srcset; }
-
             img.onload = function() {
               addClass(img, 'loaded');
               removeClass(img, 'loading');
@@ -1647,9 +1643,18 @@ export var tns = function(options) {
               removeClass(img, 'loading');
             }
 
+            // update srcset
+            var srcset = getAttr(img, 'data-srcset');
+            if (srcset) { img.srcset = srcset; }
+
             // update src
             img.src = getAttr(img, 'data-src');
+
             addClass(img, 'loading');
+
+            if (img.complete) {
+              img.onload();
+            }
           }
         });
       }


### PR DESCRIPTION
There an issue with IE11. When lazyload option turned on, and slider images exist in the cache, the `onload` event will not fire, and we should do this manually.