### PR TITLE
Add the "files" section to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,10 @@
     "type": "git",
     "url": "git+https://github.com/ganlanyuan/tiny-slider.git"
   },
+  "files": [
+    "dist",
+    "src"    
+  ],
   "keywords": [],
   "author": "ganlanyuan <ganlanyuan@gmail.com>",
   "license": "MIT",


### PR DESCRIPTION
No need in publishing images, html files and other useless files in npm dist. After merging this PR only these files will remain:

![image](https://user-images.githubusercontent.com/6059356/47900737-a3ce7280-de86-11e8-972d-2b6912f6d436.png)

Read more: https://docs.npmjs.com/files/package.json#files

---

Take care about the community and try to prevent this:

![image](https://user-images.githubusercontent.com/6059356/47900780-ce203000-de86-11e8-97d1-74e829b1b935.png)
