### PR TITLE
Added type definition for `autoWidth`.

### DIFF
--- a/src/tiny-slider.d.ts
+++ b/src/tiny-slider.d.ts
@@ -30,6 +30,11 @@ export interface CommonOptions {
      */
     autoHeight?: boolean;
     /**
+     * Sets the width of the slides to `auto`.
+     * @defaultValue false
+     */
+    autoWidth?: boolean;
+    /**
      * Controls width attribute of the slides.
      * @defaultValue false
      */


### PR DESCRIPTION
Type definition for `autoWidth` was missing, causing a type error in TypeScript.