### PR TITLE
Add missing types for center option to type definition file

### DIFF
--- a/src/tiny-slider.d.ts
+++ b/src/tiny-slider.d.ts
@@ -45,6 +45,11 @@ export interface CommonOptions {
      */
     edgePadding?: number;
     /**
+     * Center the active slide in the viewport.
+     * @defaultValue false
+     */
+    center?: boolean;
+    /**
      * Controls the display and functionalities of controls components (prev/next buttons). If true, display the controls and add all functionalities.
      * @defaultValue true
      */


### PR DESCRIPTION
Hi, I noticed that center option is missing type definition.  I've added this type to `CommonOptions` interface as it's available in slider options configuration as well as the responsive options configuration 