### PR TITLE
Fix for bug # 361 - Responsiveness Issue 

### DIFF
--- a/src/tiny-slider.js
+++ b/src/tiny-slider.js
@@ -1429,7 +1429,7 @@ export var tns = function(options) {
       // non-meduaqueries: IE8
       if (bpChanged && !CSSMQ) {
         // middle wrapper styles
-        if (autoHeight !== autoheightTem || speed !== speedTem) {
+        if (autoHeight !== autoHeightTem || speed !== options.speed) {
           update_carousel_transition_duration();
         }
 

--- a/src/tiny-slider.js
+++ b/src/tiny-slider.js
@@ -1423,7 +1423,7 @@ export var tns = function(options) {
       updateLiveRegion();
     }
 
-    if (itemsChanged || !carousel) { updateGallerySlidePositions(); }
+    if (itemsChanged && !carousel) { updateGallerySlidePositions(); }
 
     if (!disable && !freeze) {
       // non-meduaqueries: IE8


### PR DESCRIPTION
Changed '||' to '&&' to fix issue with responsiveness when page is resized below a breakpoint; Bug relating to #361