### PR TITLE
chore(readme): add "circles" keyword to the nav option

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,7 +274,7 @@ Or import `tns` directly start from v2.9.1
 | `controlsContainer` | Node \| String \| false | Default: false. <br> The container element/selector around the prev/next buttons. <br> `controlsContainer` must have at least 2 child elements. |
 | `prevButton` | Node \| String \| false | Default: false. <br> Customized previous buttons. <br> This option will be ignored if `controlsContainer` is a Node element or a CSS selector. |
 | `nextButton` | Node \| String \| false | Default: false. <br> Customized next buttons. <br> This option will be ignored if `controlsContainer` is a Node element or a CSS selector. |
-| `nav` | Boolean | Default: true. <br> Controls the display and functionalities of `nav` components (dots). If `true`, display the `nav` and add all functionalities. |
+| `nav` | Boolean | Default: true. <br> Controls the display and functionalities of `nav` components (dots/circles). If `true`, display the `nav` and add all functionalities. |
 | `navPosition` | "top" \| "bottom" | Default: "top". <br> Controls `nav` position. |
 | `navContainer` | Node \| String \| false | Default: false. <br> The container element/selector around the dots. <br> `navContainer` must have at least same number of children as the slides. |
 | `navAsThumbnails` | Boolean | Default: false. <br> Indecate if the dots are thurbnails. If `true`, they will always be visible even when more than 1 slides displayed in the viewport. |


### PR DESCRIPTION
I was searching "circles" on the readme page, nothing was found, then I googled "tiny-slider hide circles" and found this

![image](https://user-images.githubusercontent.com/6059356/56638067-d9a22600-6675-11e9-9739-05cd3bca60d7.png)

Google is the smartass! Highlighting "dots" when I'm searching for "circles"!

Instead of relying on Google intuition, let's make "circles" searchable in the README :)