### PR TITLE
[Safari] Check image.complete in case image has been already loaded

### DIFF
--- a/src/tiny-slider.js
+++ b/src/tiny-slider.js
@@ -1794,7 +1794,7 @@ export var tns = function(options) {
   }
 
   function imgCompleted (img) {
-    addClass(img, 'tns-complete');
+    addClass(img, imgCompleteClass);
     removeClass(img, 'loading');
     removeEvents(img, imgEvents);
   }
@@ -1822,7 +1822,10 @@ export var tns = function(options) {
 
     // check selected image classes otherwise
     imgs.forEach(function (img, index) {
-      if (hasClass(img, imgCompleteClass)) { imgs.splice(index, 1); }
+      if (hasClass(img, imgCompleteClass) || img.complete) {
+        imgLoaded(img);
+        imgs.splice(index, 1);
+      }
     });
 
     // execute callback function if selected images are all complete


### PR DESCRIPTION
This PR addresses #319 
Sometimes onload listener is added on the already loaded image so it is not getting fired. This causes an issue on both desktop and mobile Safari.