### PR TITLE
Cannot set outerHTML if parent is null. Added check for this

### DIFF
--- a/src/tiny-slider.js
+++ b/src/tiny-slider.js
@@ -1171,8 +1171,10 @@ export var tns = function(options) {
       if (typeof el === 'object') {
         var prevEl = el.previousElementSibling ? el.previousElementSibling : false,
             parentEl = el.parentNode;
-        el.outerHTML = htmlList[i];
-        options[item] = prevEl ? prevEl.nextElementSibling : parentEl.firstElementChild;
+        if (parentEl !== null) {
+          el.outerHTML = htmlList[i];
+          options[item] = prevEl ? prevEl.nextElementSibling : parentEl.firstElementChild;
+        }
       }
     });
 


### PR DESCRIPTION
I had an issue with my application not working when trying to destroy the slider. There might be some wrong implementation details on my side, but I thought I'd add a pull request to tiny-slider to fix the issue I had.

![Image of runtime error](https://i.imgur.com/skN9MPH.png)

I added a breakpoint to see what caused the error, and the error comes if `parentEl` is `null`.