### PR TITLE
Add next prev button types to TinySliderSettings def

### DIFF
--- a/src/tiny-slider.d.ts
+++ b/src/tiny-slider.d.ts
@@ -182,6 +182,18 @@ export interface TinySliderSettings extends CommonOptions {
      * Moves throughout all the slides seamlessly.
      * @defaultValue true
      */
+    nextButton?: HTMLElement | string | false;
+    /**
+     * Customized previous buttons. 
+     * This option will be ignored if controlsContainer is a Node element or a CSS selector.
+     * @defaultValue false
+     */
+    prevButton?: HTMLElement | string | false;
+    /**
+     * Customized next buttons. 
+     * This option will be ignored if controlsContainer is a Node element or a CSS selector.
+     * @defaultValue false
+     */
     loop?: boolean;
     /**
      * Moves to the opposite edge when reaching the first or last slide.


### PR DESCRIPTION
Hi👋 I wanted to add these types to the TinySliderSettings type definition since I add to manually add them to the tiny-slider type def file in my local project to get TypeScript to stop yelling at me. I wanted to pass in my own id strings for `nextButton` / `prevButton` properties to `tns` 