### PR TITLE
Added extra check if slide items are actually there

### DIFF
--- a/src/tiny-slider.js
+++ b/src/tiny-slider.js
@@ -801,7 +801,7 @@ export var tns = function(options) {
       var num = loop ? index : slideCount - 1;
 
       (function stylesApplicationCheck() {
-        slideItems[num - 1].getBoundingClientRect().right.toFixed(2) === slideItems[num].getBoundingClientRect().left.toFixed(2) ?
+        slideItems[num - 1] && slideItems[num] && slideItems[num - 1].getBoundingClientRect().right.toFixed(2) === slideItems[num].getBoundingClientRect().left.toFixed(2) ?
         initSliderTransformCore() :
         setTimeout(function(){ stylesApplicationCheck() }, 16);
       })();

--- a/src/tiny-slider.module.js
+++ b/src/tiny-slider.module.js
@@ -801,7 +801,7 @@ export var tns = function(options) {
       var num = loop ? index : slideCount - 1;
 
       (function stylesApplicationCheck() {
-        slideItems[num - 1].getBoundingClientRect().right.toFixed(2) === slideItems[num].getBoundingClientRect().left.toFixed(2) ?
+        slideItems[num - 1] && slideItems[num] && slideItems[num - 1].getBoundingClientRect().right.toFixed(2) === slideItems[num].getBoundingClientRect().left.toFixed(2) ?
         initSliderTransformCore() :
         setTimeout(function(){ stylesApplicationCheck() }, 16);
       })();


### PR DESCRIPTION
If dom content to the slider were added too slow then following error appeared:

TypeError · undefined is not an object (evaluating 'mt[t-1].getBoundingClientRect')

Eventho everything still worked fine but console throw some errors.

Added extra checks if slideItems are actually there.