### PR TITLE
Use epsilon insted of foFixed

### DIFF
--- a/src/tiny-slider.js
+++ b/src/tiny-slider.js
@@ -801,9 +801,13 @@ export var tns = function(options) {
       var num = loop ? index : slideCount - 1;
 
       (function stylesApplicationCheck() {
-        slideItems[num - 1].getBoundingClientRect().right.toFixed(2) === slideItems[num].getBoundingClientRect().left.toFixed(2) ?
-        initSliderTransformCore() :
-        setTimeout(function(){ stylesApplicationCheck() }, 16);
+        var left = slideItems[num].getBoundingClientRect().left;
+        var right = slideItems[num - 1].getBoundingClientRect().right; 
+        var epsilon = 2;
+        
+        (Math.abs(left - right) <= epsilon) ?
+          initSliderTransformCore() :
+          setTimeout(function(){ stylesApplicationCheck() }, 16);
       })();
 
     } else {


### PR DESCRIPTION
JavaScript method `toFixed()` returns a string, that's why you compare strings here (in fact, `===` operator convert it to numbers back).

Also, dont't forget about an accuracy ('153.25' !== '153.24999999999') 
https://0.30000000000000004.com/

When my team used tns with autoWidth option and the page was scaled the tns crashed.