### PR TITLE
fixing getBoudingClientRect when slider has only 1 item

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,9 @@ Tiny slider for all purposes, inspired by [Owl Carousel](https://owlcarousel2.gi
 
 **Warning**: tiny-slider works with static content and it works in the browser only. If the HTML is loaded dynamically, make sure to call `tns()` after its loading.
 
+## Install
+`bower install imp-slider` or `npm install imp-slider`
+
 ## Contents
 + [What's new](#whats-new)
 + [Features](#features)
@@ -207,9 +210,6 @@ Tiny slider for all purposes, inspired by [Owl Carousel](https://owlcarousel2.gi
 <small>* Default</small>
 
 *[top↑](#tiny-slider-2)*
-
-## Install
-`bower install tiny-slider` or `npm install tiny-slider`
 
 ## Usage
 #### 1. Add CSS (and IE8 polyfills if needed)

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Tiny slider for all purposes, inspired by [Owl Carousel](https://owlcarousel2.gi
 **Warning**: tiny-slider works with static content and it works in the browser only. If the HTML is loaded dynamically, make sure to call `tns()` after its loading.
 
 ## Install
-`bower install imp-slider` or `npm install imp-slider`
+`bower install tiny-slider` or `npm install tiny-slider`
 
 ## Contents
 + [What's new](#whats-new)

--- a/dist/tiny-slider.js
+++ b/dist/tiny-slider.js
@@ -1234,7 +1234,9 @@ var tns = function(options) {
 
       (function stylesApplicationCheck() {
         var left = slideItems[num].getBoundingClientRect().left;
-        var right = slideItems[num - 1].getBoundingClientRect().right;
+        if (num !== 0) {
+          var right = slideItems[num - 1].getBoundingClientRect().right;
+        }
 
         (Math.abs(left - right) <= 1) ?
           initSliderTransformCore() :

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "tiny-slider",
-  "version": "2.9.2",
-  "description": "Vanilla javascript slider for all purposes, inspired by Owl Carousel.",
+  "name": "tiny-slider-rct-1",
+  "version": "1.0.0",
+  "description": "Vanilla javascript slider for all purposes, inspired by Owl Carousel, inspired by tiny-slider",
   "main": "dist/tiny-slider.js",
   "types": "src/tiny-slider.d.ts",
   "directories": {
@@ -21,19 +21,19 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/ganlanyuan/tiny-slider.git"
+    "url": "git+https://github.com/RonyHernandez/tiny-slider/.git"
   },
   "files": [
     "dist",
     "src"
   ],
   "keywords": [],
-  "author": "ganlanyuan <ganlanyuan@gmail.com>",
+  "author": "ronyhc based on ganlanyuan <ganlanyuan@gmail.com>",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/ganlanyuan/tiny-slider/issues"
+    "url": "https://github.com/RonyHernandez/tiny-slider/issues"
   },
-  "homepage": "https://github.com/ganlanyuan/tiny-slider#readme",
+  "homepage": "https://github.com/RonyHernandez/tiny-slider/#readme",
   "devDependencies": {
     "babel-cli": "^6.26.0",
     "babel-core": "^6.26.3",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "tiny-slider-rct-1",
-  "version": "1.0.0",
-  "description": "Vanilla javascript slider for all purposes, inspired by Owl Carousel, inspired by tiny-slider",
+  "name": "imp-slider",
+  "version": "0.0.2",
+  "description": "this is a fork for tiny-slider with some changes, inspired by tiny-slider",
   "main": "dist/tiny-slider.js",
   "types": "src/tiny-slider.d.ts",
   "directories": {

--- a/src/tiny-slider.js
+++ b/src/tiny-slider.js
@@ -802,7 +802,10 @@ export var tns = function(options) {
 
       (function stylesApplicationCheck() {
         var left = slideItems[num].getBoundingClientRect().left;
-        var right = slideItems[num - 1].getBoundingClientRect().right;
+        
+        if(num !== 0){
+          var right = slideItems[num - 1].getBoundingClientRect().right;
+        }
 
         (Math.abs(left - right) <= 1) ?
           initSliderTransformCore() :


### PR DESCRIPTION
When AutoWidth option active and the slider has only one property, the function stylesApplicationCheck() counts the items and makes a minus 1, that makes the function to break since the num is 0.