### PR TITLE
Reinforce child elements to have an 'inline' property

### DIFF
--- a/src/tiny-slider.js
+++ b/src/tiny-slider.js
@@ -718,8 +718,13 @@ export var tns = function(options) {
     // before clone slides
     forEach(slideItems, function(item, i) {
       addClass(item, 'tns-item');
+      const { display } = getComputedStyle(item);
       if (!item.id) { item.id = slideId + '-item' + i; }
       if (!carousel && animateNormal) { addClass(item, animateNormal); }
+      if (!display.includes('inline')) {
+        item.style.display = `inline-${display}`
+      }
+
       setAttrs(item, {
         'aria-hidden': 'true',
         'tabindex': '-1'


### PR DESCRIPTION
I was setting up the slider and spend 15 minutes to figure it out that it was broken because I was using flex on my child elements. It would be nice to check if the display of the children includes 'inline' and if don't add it.