### PR TITLE
Fix mediaquerySupport helper

### DIFF
--- a/src/helpers/mediaquerySupport.js
+++ b/src/helpers/mediaquerySupport.js
@@ -3,6 +3,10 @@ import { setFakeBody } from './setFakeBody.js';
 import { resetFakeBody } from './resetFakeBody.js';
 
 export function mediaquerySupport () {
+  if (window.matchMedia || window.msMatchMedia) {
+    return true;
+  }
+  
   var doc = document,
       body = getBody(),
       docOverflow = setFakeBody(body),


### PR DESCRIPTION
The original helper doesn't work in Safari, cause many side-effects.
See #504
Use javascript native to detect media query support, before using the old way.