### PR TITLE
fix: return early when no slides to manage

### DIFF
--- a/src/tiny-slider.js
+++ b/src/tiny-slider.js
@@ -184,7 +184,7 @@ export var tns = function(options) {
   });
 
   // make sure at least 1 slide
-  if (options.container.children.length < 1) {
+  if (!options.container.children || options.container.children.length < 1) {
     if (supportConsoleWarn) { console.warn('No slides found in', options.container); }
     return;
    }


### PR DESCRIPTION
fix an exception when container element can't be found in the document