### PR TITLE
Add before & after container transform silent events

### DIFF
--- a/README.md
+++ b/README.md
@@ -478,7 +478,7 @@ slider = slider.rebuild();
 ```
 
 ## Custom Events
-Available events include: `indexChanged`, `transitionStart`, `transitionEnd`, `newBreakpointStart`, `newBreakpointEnd`, `touchStart`, `touchMove`, `touchEnd`, `dragStart`, `dragMove` and `dragEnd`.
+Available events include: `indexChanged`, `transitionStart`, `transitionEnd`, `newBreakpointStart`, `newBreakpointEnd`, `touchStart`, `touchMove`, `touchEnd`, `dragStart`, `dragMove` and `dragEnd`, `beforeContainerTransformSilent`, `afterContainerTransformSilent`.
 ```javascript
 var customizedFunction = function (info, eventName) {
   // direct access to info object

--- a/src/tiny-slider.js
+++ b/src/tiny-slider.js
@@ -2110,8 +2110,10 @@ export var tns = function(options) {
   }
 
   function doContainerTransformSilent (val) {
+    events.emit('beforeContainerTransformSilent', info());
     resetDuration(container, '0s');
     doContainerTransform(val);
+    events.emit('afterContainerTransformSilent', info());
   }
 
   function doContainerTransform (val) {


### PR DESCRIPTION
This change makes it possible to hook into the 'revolving' slides by adding 2 events.