### PR TITLE
Add conditionals to prevent JS error in getClientWidth

### DIFF
--- a/src/tiny-slider.js
+++ b/src/tiny-slider.js
@@ -545,7 +545,13 @@ export var tns = function(options) {
     rect = div.getBoundingClientRect();
     width = rect.right - rect.left;
     div.remove();
-    return width || getClientWidth(el.parentNode);
+    if (width) {
+        return width;
+    } else if (el.parentNode.parentNode !== null) {
+        getClientWidth(el.parentNode);
+    } else {
+        return;
+    }
   }
 
   function getViewportWidth () {


### PR DESCRIPTION
This is a fix for the issue here: https://github.com/ganlanyuan/tiny-slider/issues/497

In some cases, the slider is unable to get a parent width, in which case it iterates upward trying to find one. This prevents it from going all the way to the root level, which throws a Javascript error:

<img width="1538" alt="Screen Shot 2020-09-09 at 1 46 35 PM" src="https://user-images.githubusercontent.com/1002483/92657420-a59ac580-f2a9-11ea-8fb1-83fef11a61ec.png">
