### PR TITLE
Fix: stylesApplicationCheck

### DIFF
--- a/src/tiny-slider.js
+++ b/src/tiny-slider.js
@@ -806,7 +806,7 @@ export var tns = function(options) {
 
       (function stylesApplicationCheck() {
         var left = slideItems[num].getBoundingClientRect().left;
-        var right = slideItems[num - 1].getBoundingClientRect().right;
+        var right = slideItems[(num || 1) - 1].getBoundingClientRect().right;
 
         (Math.abs(left - right) <= 1) ?
           initSliderTransformCore() :


### PR DESCRIPTION
Uncaught TypeError: Cannot read property 'getBoundingClientRect' of undefined