### PR TITLE
add default class to nav buttons

### DIFF
--- a/src/tiny-slider.js
+++ b/src/tiny-slider.js
@@ -1050,7 +1050,7 @@ export var tns = function(options) {
             hiddenStr = navAsThumbnails ? '' : 'style="display:none"';
         for (var i = 0; i < slideCount; i++) {
           // hide nav items by default
-          navHtml += '<button type="button" data-nav="' + i +'" tabindex="-1" aria-controls="' + slideId + '" ' + hiddenStr + ' aria-label="' + navStr + (i + 1) +'"></button>';
+          navHtml += '<button type="button" data-nav="' + i +'" tabindex="-1" aria-controls="' + slideId + '" ' + hiddenStr + ' aria-label="' + navStr + (i + 1) +'" class = "tns-nav"></button>';
         }
         navHtml = '<div class="tns-nav" aria-label="Carousel Pagination">' + navHtml + '</div>';
         outerWrapper.insertAdjacentHTML(getInsertPosition(options.navPosition), navHtml);


### PR DESCRIPTION
Add class `tns-nav` to all dots for navigation, so that we can modify their style more easily. Use:
* `button.tns-nav` to modify the style of all buttons
* `button.tns-nav.tns-nav-active` to modify the style of the active button

Fixes #643