### PR TITLE
Fix: Slider shows space at the last when option.items is a decimal

### DIFF
--- a/src/tiny-slider.js
+++ b/src/tiny-slider.js
@@ -2092,8 +2092,9 @@ export var tns = function(options) {
         if (center) { val += getCenterGap(); }
       } else {
         var denominator = TRANSFORM ? slideCountNew : items;
+        var maxTransformVal = 100 - getOption('items') * 100 / denominator;
         if (center) { num -= getCenterGap(); }
-        val = - num * 100 / denominator;
+        val = - Math.min(num * 100 / denominator, maxTransformVal);
       }
     } else {
       val = - slidePositions[num];


### PR DESCRIPTION
Fix https://github.com/ganlanyuan/tiny-slider/issues/639