### PR TITLE
Disable next button when there're no more slides

### DIFF
--- a/src/tiny-slider.js
+++ b/src/tiny-slider.js
@@ -2035,7 +2035,7 @@ export var tns = function(options) {
     var prevDisabled = (prevIsButton) ? prevButton.disabled : isAriaDisabled(prevButton),
         nextDisabled = (nextIsButton) ? nextButton.disabled : isAriaDisabled(nextButton),
         disablePrev = (index <= indexMin) ? true : false,
-        disableNext = (!rewind && index >= indexMax) ? true : false;
+        disableNext = (!rewind && (index + getOption('items')) > indexMax) ? true : false;
 
     if (disablePrev && !prevDisabled) {
       disEnableElement(prevIsButton, prevButton, true);


### PR DESCRIPTION
Here's an example
<img width="1272" alt="Снимок экрана 2021-03-01 в 13 22 19" src="https://user-images.githubusercontent.com/10552101/109484210-369c6d80-7a91-11eb-8ee8-44d7b7cb98c8.png">

On this slide there're no more items, so the right arrow disappears.
<img width="1287" alt="Снимок экрана 2021-03-01 в 13 22 25" src="https://user-images.githubusercontent.com/10552101/109484217-39975e00-7a91-11eb-99c1-892a5be94499.png">
