### PR TITLE
Future-proof update for Dart Sass compatibility

### DIFF
--- a/src/tiny-slider.scss
+++ b/src/tiny-slider.scss
@@ -1,4 +1,5 @@
 // Version: 2.9.3
+@use "sass:math";
 
 .tns-outer {
   padding: 0 !important; // remove padding: clientWidth = width + padding (0) = width
@@ -121,7 +122,7 @@ $perpage: 3;
     overflow: hidden;
   }
   &-ct {
-    width: (100% * $count / $perpage);
+    width: (100% * math.div($count, $perpage));
     width: -webkit-calc(100% * #{$count} / #{$perpage});
     width: -moz-calc(100% * #{$count} / #{$perpage});
     width: calc(100% * #{$count} / #{$perpage});
@@ -133,7 +134,7 @@ $perpage: 3;
       clear: both;
     }
     > div {
-      width: (100% / $count);
+      width: (math.div(100%, $count));
       width: -webkit-calc(100% / #{$count});
       width: -moz-calc(100% / #{$count});
       width: calc(100% / #{$count});


### PR DESCRIPTION
Dart Sass will soon deprecate devision by slash (https://sass-lang.com/documentation/breaking-changes/slash-div) and as a fix for the deprecation warnings I've changed the devisions to use the math function