### PR TITLE
Solving deprecation warning on SASS

### DIFF
--- a/src/tiny-slider.scss
+++ b/src/tiny-slider.scss
@@ -121,7 +121,7 @@ $perpage: 3;
     overflow: hidden;
   }
   &-ct {
-    width: (100% * $count / $perpage);
+    width: math.div(100% * $count, $perpage);
     width: -webkit-calc(100% * #{$count} / #{$perpage});
     width: -moz-calc(100% * #{$count} / #{$perpage});
     width: calc(100% * #{$count} / #{$perpage});
@@ -133,7 +133,7 @@ $perpage: 3;
       clear: both;
     }
     > div {
-      width: (100% / $count);
+      width: math.div(100%, $count);
       width: -webkit-calc(100% / #{$count});
       width: -moz-calc(100% / #{$count});
       width: calc(100% / #{$count});

--- a/src/tiny-slider.scss
+++ b/src/tiny-slider.scss
@@ -1,5 +1,7 @@
 // Version: 2.9.4
 
+@use "sass:math";
+
 .tns-outer {
   padding: 0 !important; // remove padding: clientWidth = width + padding (0) = width
   [hidden] { display: none !important; }


### PR DESCRIPTION
SASS has been throwing deprecation warnings related to this breaking change:
https://sass-lang.com/documentation/breaking-changes/slash-div