### PR TITLE
Fixed Duplicate identifier 'preventScrollOnTouch'

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "tiny-slider",
-  "version": "2.9.4",
+  "name": "as-tiny-slider",
+  "version": "2.9.4.2",
   "description": "Vanilla javascript slider for all purposes, inspired by Owl Carousel.",
   "main": "dist/tiny-slider.js",
   "types": "src/tiny-slider.d.ts",
@@ -24,20 +24,20 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/ganlanyuan/tiny-slider.git"
+    "url": "git+https://github.com/asanzred/tiny-slider.git"
   },
   "files": [
     "dist",
     "src"
   ],
   "keywords": [],
-  "author": "ganlanyuan <ganlanyuan@gmail.com>",
+  "author": "asanzred <asanzred@gmail.com>",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/ganlanyuan/tiny-slider/issues"
+    "url": "https://github.com/asanzred/tiny-slider/issues"
   },
   "browserslist": "> 0.25%, not dead",
-  "homepage": "https://github.com/ganlanyuan/tiny-slider#readme",
+  "homepage": "https://github.com/asanzred/tiny-slider#readme",
   "devDependencies": {
     "@babel/cli": "^7.14.8",
     "@babel/core": "^7.15.0",

--- a/src/tiny-slider.d.ts
+++ b/src/tiny-slider.d.ts
@@ -253,12 +253,6 @@ export interface TinySliderSettings extends CommonOptions {
      */
     freezable?: boolean;
     /**
-     * Prevent page from scrolling on `touchmove`. If set to "auto", the slider will first check if the touch direction matches the slider axis, then decide 
-     * whether prevent the page scrolling or not. If set to "force", the slider will always prevent the page scrolling.
-     * @defaultValue false
-     */
-    preventScrollOnTouch?: "auto" | "force" | false;
-    /**
     * Nonce attribute for inline style tag to allow slider usage without unsafe-inline CSP Option
     * @defaultValue false
     */


### PR DESCRIPTION
Fixed last version error:

`
Error: node_modules/tiny-slider/src/tiny-slider.d.ts:243:5 - error TS2300: Duplicate identifier 'preventScrollOnTouch'.

243     preventScrollOnTouch?: "auto" | "force" | false;
        ~~~~~~~~~~~~~~~~~~~~


Error: node_modules/tiny-slider/src/tiny-slider.d.ts:260:5 - error TS2300: Duplicate identifier 'preventScrollOnTouch'.

260     preventScrollOnTouch?: "auto" | "force" | false;
        ~~~~~~~~~~~~~~~~~~~~

`