### PR TITLE
Remove duplicate definition from d.ts

### DIFF
--- a/src/tiny-slider.d.ts
+++ b/src/tiny-slider.d.ts
@@ -237,11 +237,6 @@ export interface TinySliderSettings extends CommonOptions {
      */
     preventActionWhenRunning?: boolean
     /**
-     * Prevent page from scrolling on touchmove. If set to "auto", the slider will first check if the touch direction matches the slider axis, then decide whether prevent the page scrolling or not. If set to "force", the slider will always prevent the page scrolling.
-     * @defaultValue false
-     */
-    preventScrollOnTouch?: "auto" | "force" | false;
-    /**
      * Difine the relationship between nested sliders.
      * Make sure you run the inner slider first, otherwise the height of the inner slider container will be wrong.
      * @defaultValue false


### PR DESCRIPTION
`preventScrollOnTouch` had 2 definitions in the d.ts, which caused an error in TypeScript. This PR removes the duplicate definition.