### PR TITLE
Add type for displayIndex property

### DIFF
--- a/src/tiny-slider.d.ts
+++ b/src/tiny-slider.d.ts
@@ -283,6 +283,7 @@ export interface TinySliderInfo {
     hasControls: boolean;
     index: number;
     indexCached: number;
+    displayIndex: number;
     items: number;
     navContainer?: HTMLElement;
     navCurrentIndex?: number;


### PR DESCRIPTION
Looks like the `TinySliderInfo` interface is missing a type declaration for `displayIndex`.