### PR TITLE
ganlanyuan#814 fix for sass deprecation warning

### DIFF
--- a/src/tiny-slider.scss
+++ b/src/tiny-slider.scss
@@ -121,7 +121,7 @@ $perpage: 3;
     overflow: hidden;
   }
   &-ct {
-    width: (100% * $count / $perpage);
+    width: calc(100% * $count / $perpage);
     width: -webkit-calc(100% * #{$count} / #{$perpage});
     width: -moz-calc(100% * #{$count} / #{$perpage});
     width: calc(100% * #{$count} / #{$perpage});
@@ -133,7 +133,7 @@ $perpage: 3;
       clear: both;
     }
     > div {
-      width: (100% / $count);
+      width: calc(100% / $count);
       width: -webkit-calc(100% / #{$count});
       width: -moz-calc(100% / #{$count});
       width: calc(100% / #{$count});


### PR DESCRIPTION
Fixed warning message on build: 
"Deprecation Warning: Using / for division outside of calc() is deprecated and will be removed in Dart Sass 2.0.0."