### PR TITLE
Moved inline DOM functions to within constructor

### DIFF
--- a/src/helpers/caf.js
+++ b/src/helpers/caf.js
@@ -1,4 +1,4 @@
-var win = window;
+import { win } from './dom.js';
 
 export var caf = win.cancelAnimationFrame
   || win.mozCancelAnimationFrame

--- a/src/helpers/classListSupport.js
+++ b/src/helpers/classListSupport.js
@@ -1,1 +1,3 @@
-export var classListSupport = 'classList' in document.createElement('_');
+import { classListSupport } from './dom.js';
+
+export { classListSupport };

--- a/src/helpers/docElement.js
+++ b/src/helpers/docElement.js
@@ -1,1 +1,2 @@
-export var docElement = document.documentElement;
+import { docElement } from './dom.js';
+export { docElement }

--- a/src/helpers/dom.js
+++ b/src/helpers/dom.js
@@ -1,0 +1,22 @@
+var win = {};
+var doc = {};
+var docElement = {};
+var classListSupport = {};
+
+function initDOM(){
+    win = window;
+    doc = document;
+    docElement = document.documentElement;
+    classListSupport = 'classList' in document.createElement('_');
+
+    // ChildNode.remove - runs upon DOM initialization function
+    if(!("remove" in Element.prototype)){
+        Element.prototype.remove = function(){
+        if(this.parentNode) {
+            this.parentNode.removeChild(this);
+        }
+        };
+    }
+}
+
+export { win, doc, docElement, classListSupport, initDOM };

--- a/src/helpers/raf.js
+++ b/src/helpers/raf.js
@@ -1,4 +1,4 @@
-var win = window;
+import { win } from './dom.js';
 
 export var raf = win.requestAnimationFrame
   || win.webkitRequestAnimationFrame

--- a/src/tiny-slider.js
+++ b/src/tiny-slider.js
@@ -20,6 +20,7 @@ if(!("remove" in Element.prototype)){
   };
 }
 
+import { win, doc, initDOM } from './helpers/dom.js';
 import { raf } from './helpers/raf.js';
 import { caf } from './helpers/caf.js';
 import { extend } from './helpers/extend.js';
@@ -111,9 +112,10 @@ export var tns = function(options) {
     nonce: false
   }, options || {});
 
-  var doc = document,
-      win = window,
-      KEYS = {
+  // initialize DOM objects - delayed so SSR frameworks can use module
+  initDOM();
+
+  var KEYS = {
         ENTER: 13,
         SPACE: 32,
         LEFT: 37,


### PR DESCRIPTION
Server-side Rendering enabled frameworks try to run the code beforehand. Some of them like SvelteKit don't like it when inline DOM methods are present. It's a relatively light/easy fix - we just moved the few instances of these DOM methods from within the Tiny-Slider codebase into a function that is called within the TNS constructor. 

No real changes to the code-base and yet the plugin can be used within SSR frameworks like SvelteKit. Thanks team!