### PR TITLE
Fix / for division outside of calc() is deprecated

### DIFF
--- a/src/tiny-slider.scss
+++ b/src/tiny-slider.scss
@@ -1,5 +1,7 @@
 // Version: 2.9.4
 
+@use "sass:math";
+
 .tns-outer {
   padding: 0 !important; // remove padding: clientWidth = width + padding (0) = width
   [hidden] { display: none !important; }
@@ -121,7 +123,7 @@ $perpage: 3;
     overflow: hidden;
   }
   &-ct {
-    width: (100% * $count / $perpage);
+    width: math.div(100% * $count, $perpage);
     width: -webkit-calc(100% * #{$count} / #{$perpage});
     width: -moz-calc(100% * #{$count} / #{$perpage});
     width: calc(100% * #{$count} / #{$perpage});
@@ -133,7 +135,7 @@ $perpage: 3;
       clear: both;
     }
     > div {
-      width: (100% / $count);
+      width: math.div(100%, $count);
       width: -webkit-calc(100% / #{$count});
       width: -moz-calc(100% / #{$count});
       width: calc(100% / #{$count});


### PR DESCRIPTION
Fixes #839 

Division will instead be written using the new math.div() function. This function will behave exactly the same as / does today.
Ref: https://sass-lang.com/documentation/breaking-changes/slash-div/